### PR TITLE
switch to table, optimize status, and more

### DIFF
--- a/src/htmlcmp/compare_output_server.py
+++ b/src/htmlcmp/compare_output_server.py
@@ -45,19 +45,6 @@ def result_symbol(result: str) -> str | None:
     return None
 
 
-def result_css(result: str) -> str | None:
-    if not isinstance(result, str):
-        raise TypeError("Result must be of type str")
-
-    if result == "pending":
-        return "color:blue;"
-    if result == "same":
-        return "color:green;"
-    if result == "different":
-        return "color:red;"
-    return None
-
-
 class Observer:
     def __init__(self):
         class Handler(watchdog.events.FileSystemEventHandler):
@@ -248,6 +235,11 @@ class Comparator:
         logger.debug(f"No comparison result for path: {path}")
         return None
 
+    def all_results(self) -> dict[str, str]:
+        # Snapshot the per-file results as a plain {path: result} map.
+        # Cheap O(n) dict copy used by the live-status endpoint; no tree walk.
+        return {str(path): result for path, result in list(self._result.items())}
+
 
 app = Flask("compare")
 
@@ -278,268 +270,305 @@ function updateRef(path) {
 def root():
     logger.debug("Generating root directory listing")
 
-    current_entry_id = 0
+    has_comparator = Config.comparator is not None
 
-    def next_entry_id() -> int:
-        nonlocal current_entry_id
-        entry_id = current_entry_id
-        current_entry_id += 1
-        return entry_id
+    def collect(a: Path, b: Path) -> list[dict]:
+        """Single O(n) walk producing flat leaf rows.
 
-    def generate_entry(
-        entry_id: int,
-        parrent_id: int | None,
-        depth: int,
-        is_directory: bool,
-        is_comparable: bool,
-        path: Path,
-        name: str,
-        message: str = "",
-        cmp_result: str = None,
-    ) -> str:
-        result = ""
-
-        if cmp_result is None and Config.comparator is not None:
-            cmp_result = Config.comparator.result(path)
-        is_hidden = (
-            Config.comparator is not None
-            and Config.comparator.result(path.parent) == "same"
-        )
-        is_collapsed = cmp_result == "same"
-
-        hidden_str = "hidden" if is_hidden else ""
-        result += f'<tr data-entry-id="{entry_id}" data-parent-id="{"" if parrent_id is None else parrent_id}" data-depth="{depth}" {hidden_str}>'
-
-        if is_directory:
-            result += f'<td><button class="toggle">{"▶" if is_collapsed else "▼"}</button></td>'
-        else:
-            result += "<td></td>"
-
-        if is_comparable:
-            main = f'<a href="/compare/{path}" target="_blank">{name}</a>'
-        else:
-            main = f"{name}"
-        if cmp_result is not None:
-            status = result_symbol(cmp_result)
-            style = result_css(cmp_result)
-            result += f'<td style="{style}">{status}</td>'
-        else:
-            style = ""
-            result += f"<td></td>"
-        result += f'<td class="main" style="{style}">{main}</td>'
-        result += f"<td>{message}</td>"
-
-        result += (
-            f"<td><button onclick=\"updateRef('{path}')\">update ref</button></td>"
-        )
-
-        result += "</tr>"
-
-        return result
-
-    def generate_tree(
-        a: Path, b: Path, name: str, parrent_id: int | None, depth: int
-    ) -> str:
-        result = ""
-
-        if not isinstance(a, Path) or not isinstance(b, Path):
-            raise TypeError("Paths must be of type Path")
-        if not a.is_dir() or not b.is_dir():
-            raise ValueError("Both paths must be directories")
+        One row per comparable file (and per missing file/dir). File statuses
+        are O(1) dict lookups, so there is no recursive per-directory status
+        aggregation and the whole tree is walked exactly once.
+        """
+        entries = []
 
         common_path = a.relative_to(Config.path_a)
-
-        directory_id = next_entry_id()
-        result += generate_entry(
-            directory_id,
-            parrent_id,
-            depth,
-            True,
-            False,
-            common_path,
-            name + "/",
-        )
 
         left = sorted(p.name for p in a.iterdir())
         right = sorted(p.name for p in b.iterdir())
 
-        left_files = sorted(
-            [
-                name
-                for name in left
-                if (a / name).is_file() and comparable_file(a / name)
-            ]
+        left_files = {
+            name
+            for name in left
+            if (a / name).is_file() and comparable_file(a / name)
+        }
+        right_files = {
+            name
+            for name in right
+            if (b / name).is_file() and comparable_file(b / name)
+        }
+        left_dirs = {name for name in left if (a / name).is_dir()}
+        right_dirs = {name for name in right if (b / name).is_dir()}
+
+        for name in sorted(left_files | right_files):
+            rel = common_path / name
+            if name in left_files and name in right_files:
+                result = Config.comparator.result(rel) if has_comparator else None
+                entries.append(
+                    {
+                        "path": str(rel),
+                        "comparable": True,
+                        "message": "",
+                        "result": result,
+                    }
+                )
+            elif name in right_files:
+                entries.append(
+                    {
+                        "path": str(rel),
+                        "comparable": False,
+                        "message": "missing in reference (A)",
+                        "result": "different",
+                    }
+                )
+            else:
+                entries.append(
+                    {
+                        "path": str(rel),
+                        "comparable": False,
+                        "message": "missing in monitored (B)",
+                        "result": "different",
+                    }
+                )
+
+        for name in sorted(left_dirs ^ right_dirs):
+            rel = common_path / name
+            where = "reference (A)" if name in right_dirs else "monitored (B)"
+            entries.append(
+                {
+                    "path": str(rel) + "/",
+                    "comparable": False,
+                    "message": f"directory missing in {where}",
+                    "result": "different",
+                }
+            )
+
+        for name in sorted(left_dirs & right_dirs):
+            entries.extend(collect(a / name, b / name))
+
+        return entries
+
+    entries = collect(Config.path_a, Config.path_b)
+    entries.sort(key=lambda e: e["path"])
+
+    def badge(result: str | None) -> str:
+        if result is None:
+            return ""
+        return f'<span class="badge {result}">{result_symbol(result) or ""} {result}</span>'
+
+    rows = []
+    for e in entries:
+        path = e["path"]
+        if e["comparable"]:
+            name_cell = f'<a href="/compare/{path}" target="_blank">{path}</a>'
+        else:
+            name_cell = f"<span>{path}</span>"
+        rows.append(
+            f'<tr data-path="{path}" data-status="{e["result"] or ""}">'
+            f'<td class="status">{badge(e["result"])}</td>'
+            f'<td class="path">{name_cell}</td>'
+            f'<td class="message">{e["message"]}</td>'
+            f'<td class="actions"><button class="btn" onclick="updateRef(\'{path}\')">update ref</button></td>'
+            f"</tr>"
         )
-        right_files = sorted(
-            [
-                name
-                for name in right
-                if (b / name).is_file() and comparable_file(b / name)
-            ]
-        )
 
-        left_dirs = sorted([name for name in left if (a / name).is_dir()])
-        right_dirs = sorted([name for name in right if (b / name).is_dir()])
+    log_link = ""
+    if Config.log_file is not None:
+        log_link = f'<a href="/logfile" target="_blank">log file</a>'
 
-        common_files = [name for name in left_files if name in right_files]
-        common_dirs = [name for name in left_dirs if name in right_dirs]
-
-        left_files_missing = [name for name in right_files if name not in left_files]
-        right_files_missing = [name for name in left_files if name not in right_files]
-        left_dirs_missing = [name for name in right_dirs if name not in left_dirs]
-        right_dirs_missing = [name for name in left_dirs if name not in right_dirs]
-        for name in left_files_missing:
-            result += generate_entry(
-                next_entry_id(),
-                directory_id,
-                depth + 1,
-                False,
-                False,
-                common_path / name,
-                name,
-                "file missing in A",
-                cmp_result="different",
-            )
-        for name in right_files_missing:
-            result += generate_entry(
-                next_entry_id(),
-                directory_id,
-                depth + 1,
-                False,
-                False,
-                common_path / name,
-                name,
-                "file missing in B",
-                cmp_result="different",
-            )
-        for name in left_dirs_missing:
-            result += generate_entry(
-                next_entry_id(),
-                directory_id,
-                depth + 1,
-                False,
-                False,
-                common_path / name,
-                name + "/",
-                "dir missing in A",
-                cmp_result="different",
-            )
-        for name in right_dirs_missing:
-            result += generate_entry(
-                next_entry_id(),
-                directory_id,
-                depth + 1,
-                False,
-                False,
-                common_path / name,
-                name + "/",
-                "dir missing in B",
-                cmp_result="different",
-            )
-
-        for name in common_files:
-            result += generate_entry(
-                next_entry_id(),
-                directory_id,
-                depth + 1,
-                False,
-                True,
-                common_path / name,
-                name,
-                "",
-            )
-
-        for name in common_dirs:
-            result += generate_tree(a / name, b / name, name, directory_id, depth + 1)
-
-        return result
-
-    result = """<!DOCTYPE html>
+    head = """<!DOCTYPE html>
 <html>
 <head>
+<meta charset="utf-8">
+<title>compare-html</title>
 <style>
-tr {
-  --depth: attr(data-depth number);
+:root {
+  --green: #137333; --green-bg: #e6f4ea;
+  --red: #c5221f;   --red-bg: #fce8e6;
+  --amber: #b06000; --amber-bg: #fef7e0;
+  --border: #e0e0e0; --muted: #5f6368;
 }
-.main {
-  padding-left: calc(1.0rem * var(--depth));
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  color: #202124;
+  background: #fafafa;
 }
+header {
+  position: sticky; top: 0; z-index: 2;
+  background: #fff; border-bottom: 1px solid var(--border);
+  padding: 12px 20px;
+}
+.title { font-size: 18px; font-weight: 600; }
+.paths { font-size: 12px; color: var(--muted); margin-top: 4px; }
+.paths code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+.toolbar {
+  display: flex; flex-wrap: wrap; align-items: center; gap: 8px;
+  margin-top: 10px;
+}
+.toolbar input[type="search"] {
+  flex: 1 1 220px; min-width: 160px;
+  padding: 6px 10px; border: 1px solid var(--border); border-radius: 6px;
+  font-size: 13px;
+}
+.chips { display: flex; gap: 6px; }
+.chip {
+  font-size: 12px; padding: 3px 9px; border-radius: 12px;
+  background: #f1f3f4; color: var(--muted); white-space: nowrap;
+}
+.chip.same { background: var(--green-bg); color: var(--green); }
+.chip.different { background: var(--red-bg); color: var(--red); }
+.chip.pending { background: var(--amber-bg); color: var(--amber); }
+.filters { display: flex; gap: 4px; }
+.filters button {
+  font-size: 12px; padding: 5px 10px; border: 1px solid var(--border);
+  background: #fff; border-radius: 6px; cursor: pointer; color: var(--muted);
+}
+.filters button.active { background: #202124; color: #fff; border-color: #202124; }
+.btn {
+  font-size: 12px; padding: 4px 8px; border: 1px solid var(--border);
+  background: #fff; border-radius: 6px; cursor: pointer;
+}
+.btn:hover { background: #f1f3f4; }
+table { width: 100%; border-collapse: collapse; }
+thead th {
+  position: sticky; top: 0; z-index: 1;
+  text-align: left; font-size: 12px; color: var(--muted);
+  font-weight: 600; padding: 8px 12px; background: #f8f9fa;
+  border-bottom: 1px solid var(--border);
+}
+tbody td { padding: 6px 12px; border-bottom: 1px solid #f0f0f0; font-size: 13px; }
+tbody tr:hover { background: #f8f9fa; }
+td.path { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+td.path a { color: #1a73e8; text-decoration: none; }
+td.path a:hover { text-decoration: underline; }
+td.path span { color: var(--muted); }
+td.message { color: var(--muted); font-size: 12px; }
+td.status { white-space: nowrap; }
+.badge {
+  display: inline-block; padding: 1px 8px; border-radius: 10px;
+  font-size: 11px; font-weight: 600;
+}
+.badge.same { background: var(--green-bg); color: var(--green); }
+.badge.different { background: var(--red-bg); color: var(--red); }
+.badge.pending { background: var(--amber-bg); color: var(--amber); }
 </style>
 <script src="/script.js"></script>
 </head>
 <body>
 """
 
-    result += "<p>"
-    result += "comparing<br>"
-    result += f"Reference: {Config.path_a}<br>"
-    result += f"Monitored: {Config.path_b}"
-    result += "</p>"
+    header = f"""<header>
+  <div class="title">compare-html</div>
+  <div class="paths">
+    <div>reference (A): <code>{Config.path_a}</code></div>
+    <div>monitored (B): <code>{Config.path_b}</code></div>
+  </div>
+  <div class="toolbar">
+    <input type="search" id="search" placeholder="filter by path…" oninput="applyFilter()">
+    <div class="chips">
+      <span class="chip" id="chip-total">0 total</span>
+      <span class="chip same" id="chip-same">0 same</span>
+      <span class="chip different" id="chip-different">0 diff</span>
+      <span class="chip pending" id="chip-pending">0 pending</span>
+    </div>
+    <div class="filters">
+      <button data-filter="all" class="active" onclick="setFilter(this)">All</button>
+      <button data-filter="different" onclick="setFilter(this)">Differences</button>
+      <button data-filter="pending" onclick="setFilter(this)">Pending</button>
+      <button data-filter="same" onclick="setFilter(this)">Same</button>
+    </div>
+    {log_link}
+  </div>
+</header>
+"""
 
-    if Config.log_file is not None:
-        result += "<p>"
-        result += (
-            f'<a href="/logfile" target="_blank">View log file: {Config.log_file}</a>'
-        )
-        result += "</p>"
+    table = (
+        "<table><thead><tr>"
+        "<th>Status</th><th>Path</th><th>Message</th><th>Actions</th>"
+        "</tr></thead><tbody>" + "".join(rows) + "</tbody></table>"
+    )
 
-    result += "<p>"
-    result += '<button onclick="toggleAll(true)">Expand All</button>'
-    result += '<button onclick="toggleAll(false)">Collapse All</button>'
-    result += "</p>"
-
-    result += "<table>"
-    result += "<thead>"
-    result += "<tr><td></td><td></td><td>Name</td><td>Message</td><td>Actions</td></tr>"
-    result += "</thead>"
-    result += "<tbody>"
-    result += generate_tree(Config.path_a, Config.path_b, "", None, 0)
-    result += "</tbody>"
-    result += "</table>"
-
-    result += """
+    script = (
+        """
 <script>
-document.addEventListener("click", e => {
-  if (!e.target.classList.contains("toggle")) return;
+const LIVE = """
+        + ("true" if has_comparator else "false")
+        + """;
+const SYM = {pending: "🔄", same: "✔", different: "❌"};
+let activeFilter = "all";
 
-  const row = e.target.closest("tr");
-  const id = row.dataset.entryId;
-  const expanded = e.target.textContent === "▼";
-
-  e.target.textContent = expanded ? "▶" : "▼";
-
-  toggleChildren(id, !expanded);
-});
-
-function toggleChildren(parentId, show) {
-  document.querySelectorAll(`tr[data-parent-id="${parentId}"]`)
-    .forEach(child => {
-      child.hidden = !show;
-      if (!show) {
-        toggleChildren(child.dataset.entryId, false);
-        const toggle = child.querySelector(".toggle");
-        if (toggle) toggle.textContent = "▶";
-      }
-    });
+function badgeHtml(status) {
+  if (!status) return "";
+  return `<span class="badge ${status}">${SYM[status] || ""} ${status}</span>`;
 }
 
-function toggleAll(show) {
-  document.querySelectorAll("tr")
-    .forEach(row => {
-      const isRoot = !row.dataset.parentId;
-      row.hidden = !isRoot && !show;
-      const toggle = row.querySelector(".toggle");
-      if (toggle) {
-        toggle.textContent = show ? "▼" : "▶";
+function setFilter(btn) {
+  activeFilter = btn.dataset.filter;
+  document.querySelectorAll(".filters button")
+    .forEach(b => b.classList.toggle("active", b === btn));
+  applyFilter();
+}
+
+function applyFilter() {
+  const q = document.getElementById("search").value.toLowerCase();
+  document.querySelectorAll("tbody tr").forEach(tr => {
+    const st = tr.dataset.status;
+    const matchesFilter = activeFilter === "all" || st === activeFilter;
+    const matchesSearch = !q || tr.dataset.path.toLowerCase().includes(q);
+    tr.hidden = !(matchesFilter && matchesSearch);
+  });
+}
+
+function updateSummary() {
+  const counts = {total: 0, same: 0, different: 0, pending: 0};
+  document.querySelectorAll("tbody tr").forEach(tr => {
+    counts.total++;
+    const st = tr.dataset.status;
+    if (counts[st] !== undefined) counts[st]++;
+  });
+  document.getElementById("chip-total").textContent = counts.total + " total";
+  document.getElementById("chip-same").textContent = counts.same + " same";
+  document.getElementById("chip-different").textContent = counts.different + " diff";
+  document.getElementById("chip-pending").textContent = counts.pending + " pending";
+}
+
+async function poll() {
+  try {
+    const res = await fetch("/status");
+    if (!res.ok) return;
+    const data = await res.json();
+    document.querySelectorAll("tbody tr").forEach(tr => {
+      const st = data[tr.dataset.path];
+      if (st && st !== tr.dataset.status) {
+        tr.dataset.status = st;
+        tr.querySelector(".status").innerHTML = badgeHtml(st);
       }
     });
+    updateSummary();
+    applyFilter();
+  } catch (e) {}
 }
+
+updateSummary();
+if (LIVE) setInterval(poll, 1500);
 </script>
 </body>
 </html>
 """
+    )
 
-    return result
+    return head + header + table + script
+
+
+@app.route("/status")
+def status():
+    logger.debug("Serving comparison status")
+
+    if Config.comparator is None:
+        return {}
+
+    return Config.comparator.all_results()
 
 
 @app.route("/logfile")

--- a/src/htmlcmp/compare_output_server.py
+++ b/src/htmlcmp/compare_output_server.py
@@ -428,7 +428,7 @@ header {
 .btn:hover { background: #f1f3f4; }
 table { width: 100%; border-collapse: collapse; }
 thead th {
-  position: sticky; top: 0; z-index: 1;
+  position: sticky; top: var(--header-h, 0px); z-index: 1;
   text-align: left; font-size: 12px; color: var(--muted);
   font-weight: 600; padding: 8px 12px; background: #f8f9fa;
   border-bottom: 1px solid var(--border);
@@ -545,6 +545,13 @@ async function poll() {
     applyFilter();
   } catch (e) {}
 }
+
+function syncHeaderHeight() {
+  const h = document.querySelector("header").offsetHeight;
+  document.documentElement.style.setProperty("--header-h", h + "px");
+}
+syncHeaderHeight();
+window.addEventListener("resize", syncHeaderHeight);
 
 updateSummary();
 if (LIVE) setInterval(poll, 1500);

--- a/src/htmlcmp/compare_output_server.py
+++ b/src/htmlcmp/compare_output_server.py
@@ -287,14 +287,10 @@ def root():
         right = sorted(p.name for p in b.iterdir())
 
         left_files = {
-            name
-            for name in left
-            if (a / name).is_file() and comparable_file(a / name)
+            name for name in left if (a / name).is_file() and comparable_file(a / name)
         }
         right_files = {
-            name
-            for name in right
-            if (b / name).is_file() and comparable_file(b / name)
+            name for name in right if (b / name).is_file() and comparable_file(b / name)
         }
         left_dirs = {name for name in left if (a / name).is_dir()}
         right_dirs = {name for name in right if (b / name).is_dir()}


### PR DESCRIPTION
1. Flat table instead of nested collapsible list
- One row per comparable file (and per missing file/dir), columns: Status · Path · Message · Actions.
- Path is the full relative path in a monospace font, so the hierarchy is readable without nesting.
- Rows are sorted by path. Comparable files link to the side-by-side compare view as before.

2. Fixed the slow loading (the main culprit)
- The old code was roughly O(n²): generate_tree recursed, and for every entry it called Comparator.result(path) and result(path.parent). For directories result() recursively re-walked the entire subtree (with repeated iterdir() disk I/O) to aggregate a status — recomputed from scratch on each page load.
- Now there's a single O(n) walk (collect()), and each file's status is an O(1) dict lookup. No per-directory aggregation, no parent re-checks. I dropped directory rows entirely since the full path already conveys structure.

3. Live status updates (async-friendly)
- Comparisons run in the background, so I added a lightweight /status JSON endpoint (Comparator.all_results() — a plain dict snapshot, no tree walk) that the page polls every 1.5s and patches the status badges + summary in place. No more reloading the page to see results land.

4. Visual polish
- Modern CSS: sticky header, sticky table head, zebra/hover rows, colored status badges (green/red/amber).
- A toolbar with a path search box, filter buttons (All / Differences / Pending / Same), and summary chips (total / same / diff / pending counts) that update live.