### PR TITLE
handle missing gracefully

### DIFF
--- a/src/htmlcmp/compare_output_server.py
+++ b/src/htmlcmp/compare_output_server.py
@@ -311,7 +311,7 @@ def root():
                 entries.append(
                     {
                         "path": str(rel),
-                        "comparable": False,
+                        "comparable": True,
                         "message": "missing in reference (A)",
                         "result": "different",
                     }
@@ -320,7 +320,7 @@ def root():
                 entries.append(
                     {
                         "path": str(rel),
-                        "comparable": False,
+                        "comparable": True,
                         "message": "missing in monitored (B)",
                         "result": "different",
                     }
@@ -638,6 +638,9 @@ def image_diff(path: str):
     if Config.driver is None:
         return "Image diff not available without browser driver", 404
 
+    if not (Config.path_a / path).is_file() or not (Config.path_b / path).is_file():
+        return "Image diff not available: file missing on one side", 404
+
     diff, _ = html_render_diff(
         Config.path_a / path,
         Config.path_b / path,
@@ -659,6 +662,16 @@ def file(variant: str, path: str):
         raise ValueError("Variant must be 'a' or 'b'")
 
     variant_root = Config.path_a if variant == "a" else Config.path_b
+
+    if not (variant_root / path).is_file():
+        side = "reference (A)" if variant == "a" else "monitored (B)"
+        return (
+            "<!DOCTYPE html><html><body style='margin:0;display:flex;"
+            "align-items:center;justify-content:center;height:100vh;"
+            "font-family:sans-serif;color:#5f6368;background:#fafafa;'>"
+            f"<div>file missing in {side}</div></body></html>"
+        )
+
     return send_from_directory(variant_root, path)
 
 

--- a/src/htmlcmp/compare_output_server.py
+++ b/src/htmlcmp/compare_output_server.py
@@ -272,6 +272,30 @@ def root():
 
     has_comparator = Config.comparator is not None
 
+    def collect_one_sided(existing: Path, root: Path, message: str) -> list[dict]:
+        """Walk a directory present on only one side.
+
+        Emits one row per comparable file inside it so each file stays viewable
+        (on the present side) and copyable to the reference, just like a missing
+        file. Recurses into nested directories.
+        """
+        entries = []
+
+        for child in sorted(existing.iterdir(), key=lambda p: p.name):
+            if child.is_dir():
+                entries.extend(collect_one_sided(child, root, message))
+            elif child.is_file() and comparable_file(child):
+                entries.append(
+                    {
+                        "path": str(child.relative_to(root)),
+                        "comparable": True,
+                        "message": message,
+                        "result": "different",
+                    }
+                )
+
+        return entries
+
     def collect(a: Path, b: Path) -> list[dict]:
         """Single O(n) walk producing flat leaf rows.
 
@@ -327,16 +351,18 @@ def root():
                 )
 
         for name in sorted(left_dirs ^ right_dirs):
-            rel = common_path / name
-            where = "reference (A)" if name in right_dirs else "monitored (B)"
-            entries.append(
-                {
-                    "path": str(rel) + "/",
-                    "comparable": False,
-                    "message": f"directory missing in {where}",
-                    "result": "different",
-                }
-            )
+            if name in left_dirs:
+                entries.extend(
+                    collect_one_sided(
+                        a / name, Config.path_a, "missing in monitored (B)"
+                    )
+                )
+            else:
+                entries.extend(
+                    collect_one_sided(
+                        b / name, Config.path_b, "missing in reference (A)"
+                    )
+                )
 
         for name in sorted(left_dirs & right_dirs):
             entries.extend(collect(a / name, b / name))


### PR DESCRIPTION
`collect()` — missing files are now comparable: True, so they render as clickable links into the compare view (keeping their missing in reference (A) / missing in monitored (B) message and different status). Missing directories stay non-linkable, since there's no single file to open.

`/file/<variant>/<path>` — when the file is absent on the requested side, it serves a small centered "file missing in reference (A)/monitored (B)" placeholder page instead of a raw 404, so the iframe shows something meaningful while the other side renders normally.

`/image_diff` — returns 404 when either side is missing (nothing to diff), so the diff strip's <img> just doesn't render instead of crashing on to_url's FileNotFoundError.

So now for a missing file you get:
- The existing side viewable in the compare view, the other side showing a "missing" placeholder.
- The ▶ / update ref button working for files present in monitored-but-not-reference (copies B→A, creating it). For the reverse (present in reference, missing in monitored) update-ref correctly 404s, since there's no monitored source to copy.

`/update_ref` needed no change — it already copied B→A and 404'd on a missing source. All 3 tests still pass.

---

Added a collect_one_sided() helper in root() that walks a directory present on only one side and emits one row per comparable file inside it (recursing into nested subdirectories), each marked missing in monitored (B) / missing in reference (A) with a different status. The old single opaque "directory missing" row is gone.

So if only_a_dir/ exists only in the reference, you now get:
- only_a_dir/p.html → linked, "missing in monitored (B)"
- only_a_dir/nested/q.html → linked, "missing in monitored (B)"

Each row behaves like any other missing file:
- Viewable in the compare view (present side renders, other side shows the "file missing" placeholder).
- Copyable via update-ref where a monitored source exists (B→A), creating the file/dirs as needed (shutil.copy2 plus update_ref's existing copytree path handle parent creation).

---

blocked by https://github.com/opendocument-app/compare-html/pull/12