### PR TITLE
Build multi-arch Docker image (add linux/arm64)

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -19,6 +19,9 @@ jobs:
       - name: checkout
         uses: actions/checkout@v6
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
@@ -50,6 +53,7 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM --platform=linux/amd64 ubuntu:26.04
+FROM ubuntu:26.04
+
+# Populated automatically by Docker Buildx (amd64 / arm64)
+ARG TARGETARCH
 
 ENV FIREFOX_VERSION="138.0.4"
 ENV GECKODRIVER_VERSION="0.36.0"
@@ -13,7 +16,12 @@ RUN $INSTALL wget ca-certificates xz-utils bzip2 unzip
 # firefox setup
 RUN $INSTALL libgtk-3-0t64 libasound2t64 libx11-xcb1
 
-RUN wget https://download-installer.cdn.mozilla.net/pub/firefox/releases/${FIREFOX_VERSION}/linux-x86_64/en-US/firefox-${FIREFOX_VERSION}.tar.xz && \
+RUN case "$TARGETARCH" in \
+      amd64) FFARCH=linux-x86_64 ;; \
+      arm64) FFARCH=linux-aarch64 ;; \
+      *) echo "unsupported TARGETARCH: $TARGETARCH" && exit 1 ;; \
+    esac && \
+    wget https://download-installer.cdn.mozilla.net/pub/firefox/releases/${FIREFOX_VERSION}/${FFARCH}/en-US/firefox-${FIREFOX_VERSION}.tar.xz && \
     tar -xf firefox-${FIREFOX_VERSION}.tar.xz && \
     mv firefox /usr/local/share && \
     ln -s /usr/local/share/firefox/firefox /usr/local/bin && \
@@ -22,19 +30,28 @@ RUN wget https://download-installer.cdn.mozilla.net/pub/firefox/releases/${FIREF
 RUN firefox --version
 
 # geckodriver setup
-RUN wget https://github.com/mozilla/geckodriver/releases/download/v${GECKODRIVER_VERSION}/geckodriver-v${GECKODRIVER_VERSION}-linux64.tar.gz && \
-    tar -xf geckodriver-v${GECKODRIVER_VERSION}-linux64.tar.gz && \
+RUN case "$TARGETARCH" in \
+      amd64) GDARCH=linux64 ;; \
+      arm64) GDARCH=linux-aarch64 ;; \
+      *) echo "unsupported TARGETARCH: $TARGETARCH" && exit 1 ;; \
+    esac && \
+    wget https://github.com/mozilla/geckodriver/releases/download/v${GECKODRIVER_VERSION}/geckodriver-v${GECKODRIVER_VERSION}-${GDARCH}.tar.gz && \
+    tar -xf geckodriver-v${GECKODRIVER_VERSION}-${GDARCH}.tar.gz && \
     mv geckodriver /usr/local/bin && \
-    rm geckodriver-v${GECKODRIVER_VERSION}-linux64.tar.gz
+    rm geckodriver-v${GECKODRIVER_VERSION}-${GDARCH}.tar.gz
 
 RUN geckodriver --version
 
-# chrome setup
-RUN wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb && \
-    $INSTALL ./google-chrome-stable_current_amd64.deb && \
-    rm google-chrome-stable_current_amd64.deb
-
-RUN google-chrome --version
+# chrome setup (Google Chrome ships no ARM64 Linux build, so amd64 only;
+# use --driver firefox, the default, on arm64)
+RUN if [ "$TARGETARCH" = "amd64" ]; then \
+      wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb && \
+      $INSTALL ./google-chrome-stable_current_amd64.deb && \
+      rm google-chrome-stable_current_amd64.deb && \
+      google-chrome --version ; \
+    else \
+      echo "Skipping Google Chrome on $TARGETARCH (no ARM64 build; use --driver firefox)" ; \
+    fi
 
 # install python dependencies
 COPY . /compare-html


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

## What

The published Docker image was amd64-only. This adds a **linux/arm64** build alongside amd64.

## Changes

- **Dockerfile**: now arch-aware via the Buildx-provided `TARGETARCH`.
  - Firefox and geckodriver download per-arch (`linux-x86_64`/`linux64` for amd64, `linux-aarch64` for arm64).
  - Google Chrome has **no ARM64 Linux build**, so it is installed on amd64 only. On arm64 the step is skipped with a note. This is fine because the tool defaults to `--driver firefox`; `--driver chrome` is simply unavailable on arm64.
- **.github/workflows/docker.yaml**: sets up QEMU and passes `platforms: linux/amd64,linux/arm64` to `build-push-action`, producing a multi-arch manifest.

## Verification

Built the arm64 image locally and ran it:

- `Mozilla Firefox 138.0.4` ✓
- `geckodriver 0.36.0` ✓
- `google-chrome` absent (expected on arm64) ✓